### PR TITLE
Init restriction

### DIFF
--- a/src/ERC173Initializable.sol
+++ b/src/ERC173Initializable.sol
@@ -3,7 +3,6 @@
 /**
  * Author: Lambdalf the White
  */
-
 pragma solidity >=0.8.4 <0.9.0;
 
 import {IERC173} from "@lambdalf-dev/ethereum-contracts/contracts/interfaces/IERC173.sol";

--- a/src/ERC2981Initializable.sol
+++ b/src/ERC2981Initializable.sol
@@ -3,7 +3,6 @@
 /**
  * Author: Lambdalf the White
  */
-
 pragma solidity >=0.8.4 <0.9.0;
 
 import {IERC2981} from "@lambdalf-dev/ethereum-contracts/contracts/interfaces/IERC2981.sol";

--- a/src/Migrated721.sol
+++ b/src/Migrated721.sol
@@ -3,7 +3,6 @@
 /**
  * Author: Lambdalf the White
  */
-
 pragma solidity >=0.8.4 <0.9.0;
 
 import {ERC173Initializable} from "./ERC173Initializable.sol";

--- a/src/Wrapped721.sol
+++ b/src/Wrapped721.sol
@@ -28,6 +28,7 @@ contract Wrapped721 is IERC165, ERC173Initializable, ERC2981Initializable, IERC7
   /// @param to the recipient of the ether
   /// @param amount the amount of ether being sent
   error ETHER_TRANSFER_FAIL(address to, uint256 amount);
+  error NOT_COLLECTION_OWNER();
   // **************************************
 
   // **************************************
@@ -69,10 +70,42 @@ contract Wrapped721 is IERC165, ERC173Initializable, ERC2981Initializable, IERC7
     uint96 royaltyRate_,
     string memory baseUri_
   ) public initializer {
-    underlyingAsset = IAsset(asset_);
-    _setBaseUri(baseUri_);
-    _init_ERC173(admin_);
-    _init_ERC2981(royaltyRecipient_, royaltyRate_);
+    if (asset_.code.length > 0) {
+      // address _prevAdmin_= IAsset(asset_).owner();
+      // if (tx.origin != _prevAdmin_) {
+      //   if (_prevAdmin_ != address(0)) {
+      //     revert NOT_COLLECTION_OWNER();
+      //   }
+      // }
+      // underlyingAsset = IAsset(asset_);
+      // _setBaseUri(baseUri_);
+      // _init_ERC173(admin_);
+      // _init_ERC2981(royaltyRecipient_, royaltyRate_);
+      address _prevAdmin_;
+      /// @solidity memory-safe-assembly
+      assembly {
+        mstore(0x00, 0x8da5cb5b) // owner()
+        if iszero(
+          and( // Arguments of `and` are evaluated last to first.
+            gt(returndatasize(), 0x1f), // The call must return at least 32 bytes.
+            staticcall(gas(), asset_, 0x1c, 0x04, 0x00, 0x20)
+          )
+        ) {
+          // TODO: Figure out a fallback if no owner() is found
+          revert(0x00, 0x00)
+        }
+        _prevAdmin_ := mload(0x00)
+      }
+      if (tx.origin != _prevAdmin_) {
+        if (_prevAdmin_ != address(0)) {
+          revert NOT_COLLECTION_OWNER();
+        }
+      }
+      underlyingAsset = IAsset(asset_);
+      _setBaseUri(baseUri_);
+      _init_ERC173(admin_);
+      _init_ERC2981(royaltyRecipient_, royaltyRate_);
+    }
   }
 
   // **************************************

--- a/src/Wrapped721.sol
+++ b/src/Wrapped721.sol
@@ -3,7 +3,6 @@
 /**
  * Author: Lambdalf the White
  */
-
 pragma solidity >=0.8.4 <0.9.0;
 
 import {ERC173Initializable} from "./ERC173Initializable.sol";
@@ -71,16 +70,6 @@ contract Wrapped721 is IERC165, ERC173Initializable, ERC2981Initializable, IERC7
     string memory baseUri_
   ) public initializer {
     if (asset_.code.length > 0) {
-      // address _prevAdmin_= IAsset(asset_).owner();
-      // if (tx.origin != _prevAdmin_) {
-      //   if (_prevAdmin_ != address(0)) {
-      //     revert NOT_COLLECTION_OWNER();
-      //   }
-      // }
-      // underlyingAsset = IAsset(asset_);
-      // _setBaseUri(baseUri_);
-      // _init_ERC173(admin_);
-      // _init_ERC2981(royaltyRecipient_, royaltyRate_);
       address _prevAdmin_;
       /// @solidity memory-safe-assembly
       assembly {
@@ -90,10 +79,7 @@ contract Wrapped721 is IERC165, ERC173Initializable, ERC2981Initializable, IERC7
             gt(returndatasize(), 0x1f), // The call must return at least 32 bytes.
             staticcall(gas(), asset_, 0x1c, 0x04, 0x00, 0x20)
           )
-        ) {
-          // TODO: Figure out a fallback if no owner() is found
-          revert(0x00, 0x00)
-        }
+        ) { revert(0x00, 0x00) }
         _prevAdmin_ := mload(0x00)
       }
       if (tx.origin != _prevAdmin_) {

--- a/src/interfaces/IAsset.sol
+++ b/src/interfaces/IAsset.sol
@@ -3,6 +3,7 @@
 pragma solidity >=0.8.4 <0.9.0;
 
 import {IERC721} from "@lambdalf-dev/ethereum-contracts/contracts/interfaces/IERC721.sol";
+import {IERC173} from "@lambdalf-dev/ethereum-contracts/contracts/interfaces/IERC173.sol";
 import {IERC721Metadata} from "@lambdalf-dev/ethereum-contracts/contracts/interfaces/IERC721Metadata.sol";
 
-interface IAsset is IERC721, IERC721Metadata {}
+interface IAsset is IERC173, IERC721, IERC721Metadata {}

--- a/src/mocks/Mock_ERC721AOwnable.sol
+++ b/src/mocks/Mock_ERC721AOwnable.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.4 <0.9.0;
+
+import {IERC721} from "@lambdalf-dev/ethereum-contracts/contracts/interfaces/IERC721.sol";
+import {IERC721Enumerable} from "@lambdalf-dev/ethereum-contracts/contracts/interfaces/IERC721Enumerable.sol";
+import {IERC721Metadata} from "@lambdalf-dev/ethereum-contracts/contracts/interfaces/IERC721Metadata.sol";
+import {IERC165} from "@lambdalf-dev/ethereum-contracts/contracts/interfaces/IERC165.sol";
+import {ERC173} from "@lambdalf-dev/ethereum-contracts/contracts/utils/ERC173.sol";
+import {ERC721A} from "erc721a/contracts/ERC721A.sol";
+
+/* solhint-disable */
+contract Mock_ERC721AOwnable is ERC721A, IERC165, ERC173 {
+  constructor() ERC721A("NFT Collection", "NFT") ERC173(msg.sender) {}
+
+  function mint(address recipient_, uint256 qty_) external {
+    _mint(recipient_, qty_);
+  }
+
+  function supportsInterface(bytes4 interfaceId_) public pure override(IERC165, ERC721A) returns (bool) {
+    return interfaceId_ == type(IERC721).interfaceId || interfaceId_ == type(IERC721Enumerable).interfaceId
+      || interfaceId_ == type(IERC721Metadata).interfaceId || interfaceId_ == type(IERC165).interfaceId;
+  }
+}
+/* solhint-enable */

--- a/test/Migrated721.t.sol
+++ b/test/Migrated721.t.sol
@@ -319,10 +319,7 @@ contract Unit_safeTransferFrom is Deployed {
   }
 
   function test_revertWhen_receiverContract_returns_unexpectedValue() public {
-    Mock_ERC721Receiver receivingContract = new Mock_ERC721Receiver(
-          RETVAL,
-          Mock_ERC721Receiver.Error.None
-        );
+    Mock_ERC721Receiver receivingContract = new Mock_ERC721Receiver(RETVAL, Mock_ERC721Receiver.Error.None);
     address operator = ALICE.addr;
     address tokenOwner = ALICE.addr;
     address recipient = address(receivingContract);
@@ -333,10 +330,8 @@ contract Unit_safeTransferFrom is Deployed {
   }
 
   function test_revertWhen_receiverContract_reverts_withCustomError() public {
-    Mock_ERC721Receiver receivingContract = new Mock_ERC721Receiver(
-          type(IERC721Receiver).interfaceId,
-          Mock_ERC721Receiver.Error.RevertWithError
-        );
+    Mock_ERC721Receiver receivingContract =
+      new Mock_ERC721Receiver(type(IERC721Receiver).interfaceId, Mock_ERC721Receiver.Error.RevertWithError);
     address operator = ALICE.addr;
     address tokenOwner = ALICE.addr;
     address recipient = address(receivingContract);
@@ -347,10 +342,8 @@ contract Unit_safeTransferFrom is Deployed {
   }
 
   function test_revertWhen_receiverContract_reverts_withMessage() public {
-    Mock_ERC721Receiver receivingContract = new Mock_ERC721Receiver(
-          type(IERC721Receiver).interfaceId,
-          Mock_ERC721Receiver.Error.RevertWithMessage
-        );
+    Mock_ERC721Receiver receivingContract =
+      new Mock_ERC721Receiver(type(IERC721Receiver).interfaceId, Mock_ERC721Receiver.Error.RevertWithMessage);
     address operator = ALICE.addr;
     address tokenOwner = ALICE.addr;
     address recipient = address(receivingContract);
@@ -361,10 +354,8 @@ contract Unit_safeTransferFrom is Deployed {
   }
 
   function test_revertWhen_receiverContract_reverts_withoutMessage() public {
-    Mock_ERC721Receiver receivingContract = new Mock_ERC721Receiver(
-          type(IERC721Receiver).interfaceId,
-          Mock_ERC721Receiver.Error.RevertWithoutMessage
-        );
+    Mock_ERC721Receiver receivingContract =
+      new Mock_ERC721Receiver(type(IERC721Receiver).interfaceId, Mock_ERC721Receiver.Error.RevertWithoutMessage);
     address operator = ALICE.addr;
     address tokenOwner = ALICE.addr;
     address recipient = address(receivingContract);
@@ -375,10 +366,8 @@ contract Unit_safeTransferFrom is Deployed {
   }
 
   function test_revertWhen_receiverContract_panics() public {
-    Mock_ERC721Receiver receivingContract = new Mock_ERC721Receiver(
-          type(IERC721Receiver).interfaceId,
-          Mock_ERC721Receiver.Error.Panic
-        );
+    Mock_ERC721Receiver receivingContract =
+      new Mock_ERC721Receiver(type(IERC721Receiver).interfaceId, Mock_ERC721Receiver.Error.Panic);
     address operator = ALICE.addr;
     address tokenOwner = ALICE.addr;
     address recipient = address(receivingContract);

--- a/test/TestHelper.sol
+++ b/test/TestHelper.sol
@@ -15,6 +15,8 @@ contract Accounts is Test {
   Account public RECIPIENT;
   // Default royalty recipient
   Account public ROYALTY_RECIPIENT;
+  // Default malicious user
+  Account public EVE;
 
   /// @dev Generates a user, labels its address, and funds it with test assets.
   function _createUser(string memory name) internal returns (Account memory account) {
@@ -55,5 +57,6 @@ abstract contract TestHelper is Constants, Accounts {
     OPERATOR = _createUser("Operator");
     RECIPIENT = _createUser("Recipient");
     ROYALTY_RECIPIENT = _createUser("RoyaltyRecipient");
+    EVE = _createUser("Eve");
   }
 }

--- a/test/Wrapped721.t.sol
+++ b/test/Wrapped721.t.sol
@@ -158,7 +158,7 @@ contract Unit_deployment is Deployed {
   }
 
   function test_revertWhen_underlyingAssetNotOwnable() public {
-    Mock_ERC721A nonOwnableAsset;
+    Mock_ERC721A nonOwnableAsset = new Mock_ERC721A();
     nonOwnableAsset.mint(ALICE.addr, ALICE_INIT_SUPPLY);
     nonOwnableAsset.mint(BOB.addr, BOB_SUPPLY);
     nonOwnableAsset.mint(ALICE.addr, ALICE_MORE_SUPPLY);

--- a/test/Wrapped721.t.sol
+++ b/test/Wrapped721.t.sol
@@ -451,10 +451,7 @@ contract Unit_safeTransferFrom is Deployed {
 
   function test_revertWhen_receiverContract_returns_unexpectedValue() public {
     _wrapFixture();
-    Mock_ERC721Receiver receivingContract = new Mock_ERC721Receiver(
-          RETVAL,
-          Mock_ERC721Receiver.Error.None
-        );
+    Mock_ERC721Receiver receivingContract = new Mock_ERC721Receiver(RETVAL, Mock_ERC721Receiver.Error.None);
     address operator = ALICE.addr;
     address tokenOwner = ALICE.addr;
     address recipient = address(receivingContract);
@@ -469,10 +466,8 @@ contract Unit_safeTransferFrom is Deployed {
 
   function test_revertWhen_receiverContract_reverts_withCustomError() public {
     _wrapFixture();
-    Mock_ERC721Receiver receivingContract = new Mock_ERC721Receiver(
-          type(IERC721Receiver).interfaceId,
-          Mock_ERC721Receiver.Error.RevertWithError
-        );
+    Mock_ERC721Receiver receivingContract =
+      new Mock_ERC721Receiver(type(IERC721Receiver).interfaceId, Mock_ERC721Receiver.Error.RevertWithError);
     address operator = ALICE.addr;
     address tokenOwner = ALICE.addr;
     address recipient = address(receivingContract);
@@ -487,10 +482,8 @@ contract Unit_safeTransferFrom is Deployed {
 
   function test_revertWhen_receiverContract_reverts_withMessage() public {
     _wrapFixture();
-    Mock_ERC721Receiver receivingContract = new Mock_ERC721Receiver(
-          type(IERC721Receiver).interfaceId,
-          Mock_ERC721Receiver.Error.RevertWithMessage
-        );
+    Mock_ERC721Receiver receivingContract =
+      new Mock_ERC721Receiver(type(IERC721Receiver).interfaceId, Mock_ERC721Receiver.Error.RevertWithMessage);
     address operator = ALICE.addr;
     address tokenOwner = ALICE.addr;
     address recipient = address(receivingContract);
@@ -505,10 +498,8 @@ contract Unit_safeTransferFrom is Deployed {
 
   function test_revertWhen_receiverContract_reverts_withoutMessage() public {
     _wrapFixture();
-    Mock_ERC721Receiver receivingContract = new Mock_ERC721Receiver(
-          type(IERC721Receiver).interfaceId,
-          Mock_ERC721Receiver.Error.RevertWithoutMessage
-        );
+    Mock_ERC721Receiver receivingContract =
+      new Mock_ERC721Receiver(type(IERC721Receiver).interfaceId, Mock_ERC721Receiver.Error.RevertWithoutMessage);
     address operator = ALICE.addr;
     address tokenOwner = ALICE.addr;
     address recipient = address(receivingContract);
@@ -523,10 +514,8 @@ contract Unit_safeTransferFrom is Deployed {
 
   function test_revertWhen_receiverContract_panics() public {
     _wrapFixture();
-    Mock_ERC721Receiver receivingContract = new Mock_ERC721Receiver(
-          type(IERC721Receiver).interfaceId,
-          Mock_ERC721Receiver.Error.Panic
-        );
+    Mock_ERC721Receiver receivingContract =
+      new Mock_ERC721Receiver(type(IERC721Receiver).interfaceId, Mock_ERC721Receiver.Error.Panic);
     address operator = ALICE.addr;
     address tokenOwner = ALICE.addr;
     address recipient = address(receivingContract);


### PR DESCRIPTION
Added restriction on Wrapped721 initializer to prevent hijacking of collection by malicious user.
Note: if underlying asset does not have an `0wner()` function, it will not be possible to migrate.